### PR TITLE
refactor: improve layout and responsiveness for small screens in epis…

### DIFF
--- a/styles/episode.css
+++ b/styles/episode.css
@@ -14,6 +14,11 @@
                         font-size: var(--font-size-xxxl);
                         font-weight: var(--font-weight-bold);
                     }
+
+                    @media (max-width: 576px) {
+                        padding-top: var(--spacing-lg);
+                        li:nth-child(2) a { font-size: var(--font-size-xxl); }
+                    }
                 }
             }
 
@@ -53,6 +58,38 @@
                     }
                 }
             }
+
+            @media (max-width: 576px) {
+                display: flex;
+                flex-direction: column;
+
+                .select-view {
+                    display: grid;
+                    grid-template-columns: repeat(2, 1fr);
+                    gap: var(--spacing-sm);
+
+                    .selectpicker {
+                        margin: 0;
+                        width: 100%;
+                    }
+                }
+
+                .select-pagination {
+                    position: static;
+                    margin-top: var(--spacing-sm);
+
+                    .nav-links {
+                        display: grid;
+                        grid-template-columns: repeat(2, 1fr);
+
+                        .btn {
+                            display: flex;
+                            justify-content: center;
+                            align-items: center;
+                        }
+                    }
+                }
+            }
         }
 
         .entry-content {
@@ -67,6 +104,7 @@
             #chapter-video-frame {
                 p:nth-child(1), iframe {
                     width: calc(var(--breakpoint-xl) - 72px);
+                    max-width: calc(100vw - var(--spacing-xl) * 2);
                     height: calc(100vh - 375px);
                     max-height: 636px;
                 }
@@ -98,6 +136,11 @@
                         width: 350px;
                         font-size: var(--font-size-lg);
                         text-align: center;
+
+                        @media (max-width: 576px) {
+                            width: 100%;
+                            padding: 0 var(--spacing-sm);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request introduces responsive design improvements to the `styles/episode.css` file, ensuring better usability on smaller screens. The key changes include adding media queries for mobile devices, adjusting layout and spacing, and improving element sizing for responsiveness.

### Responsive design improvements:

* Added a media query for screens with a maximum width of 576px to adjust padding and font size for list items in the episode section. (`li:nth-child(2) a` font size reduced for smaller screens)
* Introduced a flexbox layout for mobile screens, reorganizing the `select-view` and `select-pagination` sections into grid layouts for better alignment and spacing. Adjustments include setting `selectpicker` to full width and centering navigation buttons.
* Updated the `#chapter-video-frame` to include a `max-width` property, ensuring the video frame scales appropriately within the viewport on smaller screens.
* Modified the width and padding of elements within a specific section to ensure they adapt to smaller screens, maintaining proper alignment and readability.