### PR TITLE
fix(v1.2.0): adapter le style sombre sur plusieurs pages et corriger des bugs responsive

### DIFF
--- a/versions/v120/main.css
+++ b/versions/v120/main.css
@@ -43,6 +43,13 @@ i.icon.ion-ios-search {
 i.icon.ion-ios-search::before {
   content: none !important;
 }
+.open-search-main-menu .ion-android-close {
+  display: none !important;
+}
+.open-search-main-menu.search-open i.icon.ion-ios-search {
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M18 6L6 18M6 6l12 12' stroke='black' stroke-width='2.5' stroke-linecap='round' fill='none'/></svg>") no-repeat center / contain !important;
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M18 6L6 18M6 6l12 12' stroke='black' stroke-width='2.5' stroke-linecap='round' fill='none'/></svg>") no-repeat center / contain !important;
+}
 .ratings_stars {
   color: var(--color-brand) !important;
 }

--- a/versions/v120/main.css
+++ b/versions/v120/main.css
@@ -1,3 +1,5 @@
+@import "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css";
+@import "https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css";
 @import "../v200/variables.css";
 
 /* éléments suprimer */
@@ -19,8 +21,27 @@ body {
 span, a, a.open-search-main-menu:hover i.icon.ion-ios-search, .h4 {
   color: var(--color-primary) !important;
 }
-.btn-link, i.icon.ion-ios-search, .asp_res_url {
+.btn-link, .asp_res_url {
   color: var(--color-black) !important;
+}
+.open-search-main-menu {
+  background-color: var(--color-bg-light) !important;
+}
+.open-search-main-menu:hover {
+  background-color: var(--color-zone-hover) !important;
+}
+
+i.icon.ion-ios-search {
+  display: inline-block !important;
+  width: 22px !important;
+  height: 22px !important;
+  vertical-align: middle !important;
+  background-color: var(--color-primary) !important;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M221.09 64a157.09 157.09 0 1 0 157.09 157.09A157.1 157.1 0 0 0 221.09 64z' fill='none' stroke='black' stroke-miterlimit='10' stroke-width='32'/><path stroke-linecap='round' stroke-miterlimit='10' stroke-width='32' fill='none' stroke='black' d='M338.29 338.29 448 448'/></svg>") no-repeat center / contain !important;
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M221.09 64a157.09 157.09 0 1 0 157.09 157.09A157.1 157.1 0 0 0 221.09 64z' fill='none' stroke='black' stroke-miterlimit='10' stroke-width='32'/><path stroke-linecap='round' stroke-miterlimit='10' stroke-width='32' fill='none' stroke='black' d='M338.29 338.29 448 448'/></svg>") no-repeat center / contain !important;
+}
+i.icon.ion-ios-search::before {
+  content: none !important;
 }
 .ratings_stars {
   color: var(--color-brand) !important;
@@ -175,15 +196,57 @@ span, a, a.open-search-main-menu:hover i.icon.ion-ios-search, .h4 {
 }
 .c-search-header__wrapper {
   background-color: var(--color-black) !important;
-  background-image: none !important;
   display: flex !important;
   justify-content: center !important;
   label, button {
     color: var(--color-primary) !important;
   }
 }
+html:not(.theme-light) .c-search-header__wrapper {
+  background-image: url("https://i.postimg.cc/MHZtp3Bb/black-bg-search.jpg") !important;
+  background-size: cover !important;
+  background-position: center !important;
+}
+.c-search-header__wrapper .search-form .search-field {
+  background-color: var(--color-bg-light) !important;
+  color: var(--color-primary) !important;
+  border-color: var(--color-border) !important;
+}
+.c-search-header__wrapper .search-form .search-field::placeholder {
+  color: var(--color-tertiary) !important;
+}
+.c-search-header__wrapper .search-form {
+  position: relative !important;
+}
+.c-search-header__wrapper .search-form::after {
+  content: "" !important;
+  position: absolute !important;
+  right: 30px !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+  width: 22px !important;
+  height: 22px !important;
+  background-color: var(--color-primary) !important;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M221.09 64a157.09 157.09 0 1 0 157.09 157.09A157.1 157.1 0 0 0 221.09 64z' fill='none' stroke='black' stroke-miterlimit='10' stroke-width='32'/><path stroke-linecap='round' stroke-miterlimit='10' stroke-width='32' fill='none' stroke='black' d='M338.29 338.29 448 448'/></svg>") no-repeat center / contain !important;
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M221.09 64a157.09 157.09 0 1 0 157.09 157.09A157.1 157.1 0 0 0 221.09 64z' fill='none' stroke='black' stroke-miterlimit='10' stroke-width='32'/><path stroke-linecap='round' stroke-miterlimit='10' stroke-width='32' fill='none' stroke='black' d='M338.29 338.29 448 448'/></svg>") no-repeat center / contain !important;
+  pointer-events: none !important;
+}
+.c-search-header__wrapper .search-form .search-submit {
+  background-color: var(--color-bg-light) !important;
+  color: transparent !important;
+  border-color: var(--color-border) !important;
+}
 
 /* page anime */
+.wp-manga .c-btn.c-btn_style-1 {
+  background-color: var(--color-bg-light) !important;
+  color: var(--color-primary) !important;
+  border-color: var(--color-border) !important;
+}
+.wp-manga .c-btn.c-btn_style-1:hover {
+  background-color: var(--color-zone) !important;
+}
+
 .wp-manga {
   .profile-manga {
     background-color: var(--color-black) !important;
@@ -223,6 +286,109 @@ span, a, a.open-search-main-menu:hover i.icon.ion-ios-search, .h4 {
         color: var(--color-border) !important;
       }
     }
+  }
+}
+
+/* image de fond sombre - uniquement en thème sombre */
+html:not(.theme-light) .archive .c-breadcrumb-wrapper,
+html:not(.theme-light) .wp-manga .profile-manga {
+  background-image: url("https://i.postimg.cc/MHZtp3Bb/black-bg-search.jpg") !important;
+  background-size: cover !important;
+  background-position: center !important;
+}
+
+/* pages archive (anime-genre, anime-release) */
+.archive .c-breadcrumb-wrapper > .container {
+  max-width: 1200px !important;
+  margin: 0 auto !important;
+}
+.archive .breadcrumb {
+  background-color: transparent !important;
+}
+.archive .breadcrumb a {
+  color: var(--color-secondary) !important;
+}
+.archive .breadcrumb a:hover {
+  color: var(--color-brand) !important;
+}
+.archive .breadcrumb li:last-child a {
+  color: var(--color-primary) !important;
+}
+.archive .genres_wrap .c-blog__heading {
+  background: var(--color-bg-light) !important;
+}
+.archive .genres_wrap .c-blog__heading h5 {
+  color: var(--color-primary) !important;
+}
+.archive .genres_wrap .genres__collapse .row.genres ul li a {
+  color: var(--color-secondary) !important;
+}
+.archive .genres_wrap .genres__collapse .row.genres ul li a:hover {
+  color: var(--color-primary) !important;
+}
+
+/* responsivité - menu mobile */
+@media (max-width: 992px) {
+  .site-header .main-navigation .main-menu {
+    display: none !important;
+  }
+  .site-header .c-togle__menu .menu_icon__open span {
+    background-color: var(--color-primary) !important;
+  }
+  .mobile-menu {
+    background-color: var(--color-bg) !important;
+    border-color: var(--color-border) !important;
+    z-index: 999 !important;
+  }
+  .mobile-menu .off-menu {
+    background-color: var(--color-bg) !important;
+  }
+  .mobile-menu .nav.navbar-nav.main-navbar .menu-item a {
+    color: var(--color-primary) !important;
+    background-color: transparent !important;
+  }
+  .mobile-menu .nav.navbar-nav.main-navbar .menu-item a:hover {
+    color: var(--color-brand) !important;
+  }
+  .mobile-menu .close-nav .menu_icon__close span {
+    background-color: var(--color-primary) !important;
+  }
+}
+
+/* responsivité - contenu principal (override de la marge négative desktop) */
+@media (max-width: 1200px) {
+  .content-area .container .row .main-col .main-col-inner,
+  .content-area .container .row .col-md-8 .main-col-inner,
+  .content-area .container .row .col-sm-8 .main-col-inner,
+  .content-area .container .row .main-col .c-page,
+  .content-area .container .row .col-md-8 .c-page,
+  .content-area .container .row .col-sm-8 .c-page {
+    margin: 0 !important;
+    width: 100% !important;
+  }
+}
+
+/* responsivité - section archive */
+@media (max-width: 768px) {
+  .archive .c-breadcrumb-wrapper {
+    padding: 10px 0 !important;
+  }
+  .archive .c-breadcrumb-wrapper > .container {
+    max-width: 100% !important;
+    padding: 0 15px !important;
+  }
+  .archive .breadcrumb {
+    padding: 5px 0 !important;
+    font-size: 13px !important;
+  }
+  .archive .genres_wrap .c-blog__heading {
+    margin: 5px 0 !important;
+  }
+  .archive .genres_wrap .genres__collapse .row.genres ul li {
+    padding: 4px !important;
+  }
+  .archive .genres_wrap .genres__collapse .row.genres ul li a {
+    font-size: 13px !important;
   }
 }
 


### PR DESCRIPTION
## Problème

La version legacy v1.2.0 du thème n'était pas correctement adaptée sur plusieurs pages du site, contrairement à la v2.0.0 :

- Pages \`anime-genre/*\` et \`anime-release/*\` : pas de styles sombres, image de fond claire visible
- Page anime (\`/anime/*\`) : image de fond claire visible derrière le profil de l'animé
- Page de recherche (\`?s=&post_type=wp-manga\`) : input et bouton submit non adaptés au thème
- Icône de recherche dans le header : invisible (police Ionicons non chargée en v1.2.0)
- Menu mobile : aucun style appliqué, illisible
- Marge négative \`-20%\` du contenu principal qui poussait les images hors de l'écran sur petits écrans

## Corrections apportées

### Pages archive (\`anime-genre\`, \`anime-release\`)
- Styles complets pour breadcrumb, bloc genres et liens
- Image de fond \`bg-search.jpg\` remplacée par une version sombre (uniquement en thème sombre)
- Conteneur centré avec \`max-width: 1200px\` pour une meilleure lisibilité

### Page anime
- Image de fond \`bg-search.jpg\` derrière le profil remplacée par la version sombre (uniquement en thème sombre)
- Boutons "Premier EP" / "Dernier EP" qui s'adaptent désormais au thème via les variables CSS

### Page de recherche
- Image de fond conditionnelle au thème
- Input et bouton submit stylisés avec les variables CSS pour s'adapter automatiquement au thème
- Ajout d'une icône SVG de loupe sur le bouton submit via \`::after\` (le pseudo-élément ne pouvant pas être appliqué directement sur \`<input>\`)

### Icône de recherche du header
- Remplacement de l'icône Ionicons (qui ne se chargeait pas en v1.2.0) par un SVG inline en \`mask-image\`
- L'icône s'adapte automatiquement à la couleur du thème via \`background-color: var(--color-primary)\`
- Ajout d'un fond adaptatif sur le bouton \`.open-search-main-menu\` pour assurer la lisibilité

### Responsivité
- Menu mobile : styles complets pour le bouton hamburger, le menu off-canvas et le bouton de fermeture
- Section archive : padding et font-size réduits sur mobile
- Correction de la marge négative \`-20%\` qui poussait le contenu hors de l'écran à \\< 1200px

### Conditionnement par thème
- Toutes les images de fond sombres sont appliquées uniquement quand \`html\` n'a pas la classe \`.theme-light\`
- Les couleurs utilisent les variables CSS pour basculer automatiquement entre les deux thèmes

## Fichier modifié

- \`versions/v120/main.css\` : 168 ajouts, 2 suppressions