### PR TITLE
fix(popup): corriger ReferenceError 'data is not defined' lors du changement de version

### DIFF
--- a/modal/popup.js
+++ b/modal/popup.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const v = versionSelect.value;
         chrome.storage.sync.set({ version: v });
         toggleSearchSelect(v);
-        toggleGenreSelect(data.version);
+        toggleGenreSelect(v);
     });
 
     searchSelector.addEventListener('change', () => {


### PR DESCRIPTION
## Problème

Lors du changement de version dans le popup (v2.0.0 → v1.2.0 ou inversement), une erreur JavaScript est levée :

\`\`\`
Uncaught ReferenceError: data is not defined
\`\`\`

## Cause

Dans \`modal/popup.js\` à la ligne 55, la fonction \`toggleGenreSelect\` est appelée avec \`data.version\`, mais la variable \`data\` n'existe que dans la portée du callback de \`chrome.storage.sync.get\` (lignes 12-40). En dehors de ce callback, \`data\` est \`undefined\`.

\`\`\`javascript
versionSelect.addEventListener('change', () => {
    const v = versionSelect.value;
    chrome.storage.sync.set({ version: v });
    toggleSearchSelect(v);
    toggleGenreSelect(data.version);  // ← data n'existe pas dans cette portée
});
\`\`\`

## Correction

Utiliser la variable locale \`v\` qui contient déjà la valeur de la nouvelle version sélectionnée :

\`\`\`javascript
toggleGenreSelect(v);
\`\`\`

## Impact

Cette erreur empêchait le bon fonctionnement du popup lors du changement de version, ce qui bloquait notamment le test de la version v1.2.0.

## Fichier modifié

- \`modal/popup.js\` : 1 ligne modifiée