### PR TITLE
fix(v2.0.0): appliquer l'image de fond sombre uniquement en thème sombre

### DIFF
--- a/versions/v200/home.css
+++ b/versions/v200/home.css
@@ -1,7 +1,10 @@
-.archive .site-content .c-breadcrumb-wrapper {
+html:not(.theme-light) .archive .site-content .c-breadcrumb-wrapper {
     background-image: url("https://i.postimg.cc/MHZtp3Bb/black-bg-search.jpg") !important;
     background-size: cover;
     background-position: center;
+}
+
+.archive .site-content .c-breadcrumb-wrapper {
     padding: var(--spacing-md) 0;
 
     .breadcrumb {


### PR DESCRIPTION
## Problème

Dans la PR précédente (#19) qui ajoutait le style des pages \`anime-genre/*\` et \`anime-release/*\`, l'image de fond sombre est appliquée sur \`.archive .site-content .c-breadcrumb-wrapper\` sans tenir compte du thème actif.

Résultat : en thème clair, l'image sombre reste appliquée alors qu'elle devrait laisser place à l'image originale du site (claire) pour rester cohérente avec le thème sélectionné.

## Cause

```css
.archive .site-content .c-breadcrumb-wrapper {
    background-image: url("...black-bg-search.jpg") !important;
    ...
}
```

L'\`!important\` surcharge le style inline du thème WordPress dans tous les cas, y compris en thème clair.

## Correction

Conditionner la règle d'image de fond à l'absence de la classe \`.theme-light\` sur l'élément \`<html>\` :

```css
html:not(.theme-light) .archive .site-content .c-breadcrumb-wrapper {
    background-image: url("...black-bg-search.jpg") !important;
    background-size: cover;
    background-position: center;
}

.archive .site-content .c-breadcrumb-wrapper {
    padding: var(--spacing-md) 0;
    ...
}
```

Ainsi :
- **Thème sombre** : l'image sombre s'applique (comportement actuel conservé)
- **Thème clair** : la règle ne s'applique pas, l'image inline du thème WordPress (\`bg-search.jpg\` claire) reste visible

## Fichier modifié

- \`versions/v200/home.css\` : 4 ajouts, 1 suppression