### PR TITLE
fix: ajouter la classe .fab manquante sur l'icone Discord du footer

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,8 @@
         "scripts/auto-select.js",
         "scripts/vf-vostfr-switch.js",
         "scripts/characters.js",
-        "scripts/scroll-to-watched.js"
+        "scripts/scroll-to-watched.js",
+        "scripts/fix-discord-icon.js"
       ],
       "run_at": "document_start"
     }

--- a/scripts/fix-discord-icon.js
+++ b/scripts/fix-discord-icon.js
@@ -1,0 +1,33 @@
+(() => {
+    // Fix d'un bug du site voir-anime.to : dans le footer, l'icône Discord
+    // utilise <i class="fa-discord"> mais il manque la classe `.fab` (Font
+    // Awesome Brands) nécessaire au rendu de l'icône. Ce script ajoute la
+    // classe manquante à toutes les balises concernées, sur toutes les pages.
+    // Compatible v1 et v2 puisque le bug est dans le HTML du site, pas le CSS.
+
+    const fixIcons = (root = document) => {
+        root.querySelectorAll('i.fa-discord:not(.fab)').forEach(el => el.classList.add('fab'));
+    };
+
+    const observer = new MutationObserver(records => {
+        records.forEach(rec => rec.addedNodes.forEach(n => {
+            if (n.nodeType !== 1) return;
+            if (n.matches && n.matches('i.fa-discord:not(.fab)')) n.classList.add('fab');
+            if (n.querySelectorAll) fixIcons(n);
+        }));
+    });
+
+    const init = () => {
+        fixIcons();
+        observer.observe(document.documentElement, { childList: true, subtree: true });
+    };
+
+    chrome.storage.sync.get({ enabled: true }, (data) => {
+        if (!data.enabled) return;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
+    });
+})();


### PR DESCRIPTION
## Description

Bug observé : dans le footer du site (présent sur toutes les pages), l'icône Discord ne s'affiche pas — un petit carré vide apparaît à la place.

## Cause

Le HTML du site contient :

```html
<i class="fa-discord" aria-hidden="true"></i>
```

Il manque la classe \`.fab\` (Font Awesome Brands) qui est nécessaire au rendu de l'icône Discord. Pour comparaison, l'icône Twitter juste à côté l'a bien :

```html
<i class="fab fa-twitter" aria-hidden="true"></i>
```

C'est un bug du site lui-même, pas de l'extension. Mais on peut facilement le corriger côté extension en attendant que le site soit patché.

## Solution

Nouveau script \`scripts/fix-discord-icon.js\` qui :
- Sélectionne tous les \`<i class="fa-discord">\` qui n'ont pas déjà la classe \`.fab\` et l'ajoute
- Utilise un \`MutationObserver\` pour catcher d'éventuels ajouts dynamiques
- Respecte le toggle \`enabled\` de l'extension (n'agit pas si l'extension est désactivée)
- Compatible v1 et v2 (le fix est sur le HTML, pas sur le CSS de l'extension)

Le script est ajouté dans \`content_scripts.js\` du manifest.

## Avant / Après

<!-- À compléter par les screenshots avant/après -->

**Avant :**
<img width="121" height="55" alt="image" src="https://github.com/user-attachments/assets/4e5ddd71-c9e1-40f9-9ae7-a17d2cd2f286" />

**Après :**
<img width="121" height="55" alt="image" src="https://github.com/user-attachments/assets/9321dc63-929f-4d74-94ae-959a9b717560" />


## Test plan

- [x] Charger l'extension, aller sur n'importe quelle page du site
- [x] Scroller jusqu'au footer
- [x] L'icône Discord doit maintenant s'afficher correctement à côté de l'icône Twitter
- [x] Tester sur la v1 et la v2 (les deux doivent fonctionner)
- [x] Désactiver l'extension → le bug original réapparait (logique, le site n'a pas été modifié)