### PR TITLE
fix: les scripts de features respectent le toggle enabled et la version v2

### DIFF
--- a/content.js
+++ b/content.js
@@ -17,13 +17,21 @@
         listPattern: /^https?:\/\/[^/]+\/liste-danimes\/.*$/
     };
 
-    let config = {
+    // Defaults centralisés. Toutes les clés de config sont ici pour qu'un seul
+    // appel `chrome.storage.sync.get(DEFAULTS, ...)` récupère tout, et que le
+    // résultat soit broadcasté aux autres scripts (cf. dispatch plus bas).
+    const DEFAULTS = {
         enabled: true,
         version: '2',
         theme: 'dark',
         search: 'fixe',
-        genre: 'hide'
+        genre: 'hide',
+        autoLecteurEnabled: false,
+        lecteurPreferred: 'LECTEUR myTV',
+        autoValiderEnabled: false
     };
+
+    let config = { ...DEFAULTS };
 
     const createLink = href => {
         const l = document.createElement('link');
@@ -88,9 +96,18 @@
         }));
     });
 
+    // Broadcast la config aux autres content scripts. Ils peuvent soit lire
+    // le dataset directement (synchronously si la config est déjà broadcastée),
+    // soit attendre l'event `darkmod:ready` s'ils s'initialisent avant nous.
+    const broadcastConfig = () => {
+        document.documentElement.dataset.darkmodConfig = JSON.stringify(config);
+        document.documentElement.dispatchEvent(new Event('darkmod:ready'));
+    };
+
     function init() {
-        chrome.storage.sync.get(config, data => {
+        chrome.storage.sync.get(DEFAULTS, data => {
             config = data;
+            broadcastConfig();
             if (!config.enabled) {
                 removeInjected();
                 return;
@@ -106,7 +123,7 @@
         });
 
         chrome.storage.onChanged.addListener((changes, area) => {
-            if (area === 'sync' && ['enabled', 'version', 'theme', 'search', 'genre', 'autoLecteurEnabled', 'lecteurPreferred', 'autoValiderEnabled'].some(k => k in changes)) {
+            if (area === 'sync' && Object.keys(DEFAULTS).some(k => k in changes)) {
                 window.location.reload();
             }
         });

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,7 @@
     {
       "matches": ["*://*.voir-anime.to/*"],
       "js": [
+        "scripts/utils.js",
         "content.js",
         "scripts/remove-image-sizes.js",
         "scripts/auto-select.js",

--- a/scripts/auto-select.js
+++ b/scripts/auto-select.js
@@ -1,9 +1,17 @@
 (() => {
-    let config = {
-        enabled: true,
-        autoLecteurEnabled: false,
-        lecteurPreferred: 'LECTEUR myTV',
-        autoValiderEnabled: false
+    let config = {};
+
+    // Récupère la config broadcastée par content.js (via le dataset si déjà
+    // dispo, sinon attend l'event darkmod:ready).
+    const onConfig = (callback) => {
+        const root = document.documentElement;
+        const read = () => {
+            const raw = root.dataset.darkmodConfig;
+            if (!raw) return;
+            try { callback(JSON.parse(raw)); } catch {}
+        };
+        if (root.dataset.darkmodConfig) read();
+        else root.addEventListener('darkmod:ready', read, { once: true });
     };
 
     const selectPreferredLecteur = (lecteurName) => {
@@ -109,17 +117,13 @@
         }, 1000);
     };
 
-    const init = () => {
-        chrome.storage.sync.get(config, (data) => {
-            config = { ...config, ...data };
-            if (!config.enabled) return;
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', runAutoSelect);
-            } else {
-                runAutoSelect();
-            }
-        });
-    };
-
-    init();
+    onConfig((cfg) => {
+        config = cfg;
+        if (!config.enabled) return;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', runAutoSelect);
+        } else {
+            runAutoSelect();
+        }
+    });
 })();

--- a/scripts/auto-select.js
+++ b/scripts/auto-select.js
@@ -1,5 +1,6 @@
 (() => {
     let config = {
+        enabled: true,
         autoLecteurEnabled: false,
         lecteurPreferred: 'LECTEUR myTV',
         autoValiderEnabled: false
@@ -111,6 +112,7 @@
     const init = () => {
         chrome.storage.sync.get(config, (data) => {
             config = { ...config, ...data };
+            if (!config.enabled) return;
             if (document.readyState === 'loading') {
                 document.addEventListener('DOMContentLoaded', runAutoSelect);
             } else {

--- a/scripts/auto-select.js
+++ b/scripts/auto-select.js
@@ -1,18 +1,6 @@
 (() => {
     let config = {};
 
-    // Récupère la config broadcastée par content.js (via le dataset si déjà
-    // dispo, sinon attend l'event darkmod:ready).
-    const onConfig = (callback) => {
-        const root = document.documentElement;
-        const read = () => {
-            const raw = root.dataset.darkmodConfig;
-            if (!raw) return;
-            try { callback(JSON.parse(raw)); } catch {}
-        };
-        if (root.dataset.darkmodConfig) read();
-        else root.addEventListener('darkmod:ready', read, { once: true });
-    };
 
     const selectPreferredLecteur = (lecteurName) => {
         if (!config.autoLecteurEnabled) {
@@ -117,7 +105,7 @@
         }, 1000);
     };
 
-    onConfig((cfg) => {
+    window.onDarkmodConfig((cfg) => {
         config = cfg;
         if (!config.enabled) return;
         if (document.readyState === 'loading') {

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -277,8 +277,19 @@
         });
     };
 
-    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
-        if (!data.enabled || data.version !== '2') return;
+    const onConfig = (callback) => {
+        const root = document.documentElement;
+        const read = () => {
+            const raw = root.dataset.darkmodConfig;
+            if (!raw) return;
+            try { callback(JSON.parse(raw)); } catch {}
+        };
+        if (root.dataset.darkmodConfig) read();
+        else root.addEventListener('darkmod:ready', read, { once: true });
+    };
+
+    onConfig((config) => {
+        if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', runAnimeCharacters);
         } else {

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -277,18 +277,7 @@
         });
     };
 
-    const onConfig = (callback) => {
-        const root = document.documentElement;
-        const read = () => {
-            const raw = root.dataset.darkmodConfig;
-            if (!raw) return;
-            try { callback(JSON.parse(raw)); } catch {}
-        };
-        if (root.dataset.darkmodConfig) read();
-        else root.addEventListener('darkmod:ready', read, { once: true });
-    };
-
-    onConfig((config) => {
+    window.onDarkmodConfig((config) => {
         if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', runAnimeCharacters);

--- a/scripts/characters.js
+++ b/scripts/characters.js
@@ -277,9 +277,12 @@
         });
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', runAnimeCharacters);
-    } else {
-        runAnimeCharacters();
-    }
+    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
+        if (!data.enabled || data.version !== '2') return;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', runAnimeCharacters);
+        } else {
+            runAnimeCharacters();
+        }
+    });
 })();

--- a/scripts/remove-image-sizes.js
+++ b/scripts/remove-image-sizes.js
@@ -16,9 +16,12 @@
         imageSizesObserver.observe(document.documentElement, { childList: true, subtree: true });
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initImageSizes);
-    } else {
-        initImageSizes();
-    }
+    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
+        if (!data.enabled || data.version !== '2') return;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initImageSizes);
+        } else {
+            initImageSizes();
+        }
+    });
 })();

--- a/scripts/remove-image-sizes.js
+++ b/scripts/remove-image-sizes.js
@@ -16,18 +16,7 @@
         imageSizesObserver.observe(document.documentElement, { childList: true, subtree: true });
     };
 
-    const onConfig = (callback) => {
-        const root = document.documentElement;
-        const read = () => {
-            const raw = root.dataset.darkmodConfig;
-            if (!raw) return;
-            try { callback(JSON.parse(raw)); } catch {}
-        };
-        if (root.dataset.darkmodConfig) read();
-        else root.addEventListener('darkmod:ready', read, { once: true });
-    };
-
-    onConfig((config) => {
+    window.onDarkmodConfig((config) => {
         if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', initImageSizes);

--- a/scripts/remove-image-sizes.js
+++ b/scripts/remove-image-sizes.js
@@ -16,8 +16,19 @@
         imageSizesObserver.observe(document.documentElement, { childList: true, subtree: true });
     };
 
-    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
-        if (!data.enabled || data.version !== '2') return;
+    const onConfig = (callback) => {
+        const root = document.documentElement;
+        const read = () => {
+            const raw = root.dataset.darkmodConfig;
+            if (!raw) return;
+            try { callback(JSON.parse(raw)); } catch {}
+        };
+        if (root.dataset.darkmodConfig) read();
+        else root.addEventListener('darkmod:ready', read, { once: true });
+    };
+
+    onConfig((config) => {
+        if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', initImageSizes);
         } else {

--- a/scripts/scroll-to-watched.js
+++ b/scripts/scroll-to-watched.js
@@ -162,8 +162,19 @@
         runOnAnimePage();
     };
 
-    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
-        if (!data.enabled || data.version !== '2') return;
+    const onConfig = (callback) => {
+        const root = document.documentElement;
+        const read = () => {
+            const raw = root.dataset.darkmodConfig;
+            if (!raw) return;
+            try { callback(JSON.parse(raw)); } catch {}
+        };
+        if (root.dataset.darkmodConfig) read();
+        else root.addEventListener('darkmod:ready', read, { once: true });
+    };
+
+    onConfig((config) => {
+        if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', init);
         } else {

--- a/scripts/scroll-to-watched.js
+++ b/scripts/scroll-to-watched.js
@@ -162,18 +162,7 @@
         runOnAnimePage();
     };
 
-    const onConfig = (callback) => {
-        const root = document.documentElement;
-        const read = () => {
-            const raw = root.dataset.darkmodConfig;
-            if (!raw) return;
-            try { callback(JSON.parse(raw)); } catch {}
-        };
-        if (root.dataset.darkmodConfig) read();
-        else root.addEventListener('darkmod:ready', read, { once: true });
-    };
-
-    onConfig((config) => {
+    window.onDarkmodConfig((config) => {
         if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', init);

--- a/scripts/scroll-to-watched.js
+++ b/scripts/scroll-to-watched.js
@@ -162,9 +162,12 @@
         runOnAnimePage();
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
-    } else {
-        init();
-    }
+    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
+        if (!data.enabled || data.version !== '2') return;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
+    });
 })();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,14 @@
+(() => {
+    // Helper partagé : récupère la config broadcastée par content.js,
+    // soit en lisant le dataset (sync), soit en attendant l'event darkmod:ready.
+    window.onDarkmodConfig = (callback) => {
+        const root = document.documentElement;
+        const read = () => {
+            const raw = root.dataset.darkmodConfig;
+            if (!raw) return;
+            try { callback(JSON.parse(raw)); } catch {}
+        };
+        if (root.dataset.darkmodConfig) read();
+        else root.addEventListener('darkmod:ready', read, { once: true });
+    };
+})();

--- a/scripts/vf-vostfr-switch.js
+++ b/scripts/vf-vostfr-switch.js
@@ -105,8 +105,19 @@
         });
     };
 
-    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
-        if (!data.enabled || data.version !== '2') return;
+    const onConfig = (callback) => {
+        const root = document.documentElement;
+        const read = () => {
+            const raw = root.dataset.darkmodConfig;
+            if (!raw) return;
+            try { callback(JSON.parse(raw)); } catch {}
+        };
+        if (root.dataset.darkmodConfig) read();
+        else root.addEventListener('darkmod:ready', read, { once: true });
+    };
+
+    onConfig((config) => {
+        if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', runVfVostfrSwitch);
         } else {

--- a/scripts/vf-vostfr-switch.js
+++ b/scripts/vf-vostfr-switch.js
@@ -105,18 +105,7 @@
         });
     };
 
-    const onConfig = (callback) => {
-        const root = document.documentElement;
-        const read = () => {
-            const raw = root.dataset.darkmodConfig;
-            if (!raw) return;
-            try { callback(JSON.parse(raw)); } catch {}
-        };
-        if (root.dataset.darkmodConfig) read();
-        else root.addEventListener('darkmod:ready', read, { once: true });
-    };
-
-    onConfig((config) => {
+    window.onDarkmodConfig((config) => {
         if (!config.enabled || config.version !== '2') return;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', runVfVostfrSwitch);

--- a/scripts/vf-vostfr-switch.js
+++ b/scripts/vf-vostfr-switch.js
@@ -105,9 +105,12 @@
         });
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', runVfVostfrSwitch);
-    } else {
-        runVfVostfrSwitch();
-    }
+    chrome.storage.sync.get({ enabled: true, version: '2' }, (data) => {
+        if (!data.enabled || data.version !== '2') return;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', runVfVostfrSwitch);
+        } else {
+            runVfVostfrSwitch();
+        }
+    });
 })();


### PR DESCRIPTION
## Problème

Depuis qu'on a séparé les features dans des fichiers \`scripts/*.js\` (PR #32 et suivantes), ces scripts s'exécutent **systématiquement** sans tenir compte de la configuration utilisateur :

- Quand l'extension est **désactivée** via le toggle du popup, les scripts continuent de tourner et d'injecter leur UI (bouton \"Voir la VF\", section personnages, boutons flottants scroll-to-watched, etc.)
- Quand l'utilisateur est sur la **v1**, les features qui sont censées être **v2 only** s'exécutent quand même

Seul \`content.js\` lit \`enabled\` et \`version\` pour appliquer/retirer son CSS, mais les scripts autonomes n'ont pas cette logique.

## Solution

Ajout d'une garde au début de chaque script qui lit \`chrome.storage.sync\` et abort si la condition n'est pas remplie :

| Script | Condition pour s'exécuter |
|---|---|
| \`scripts/auto-select.js\` | \`enabled\` (fonctionne en v1 ET v2) |
| \`scripts/vf-vostfr-switch.js\` | \`enabled && version === '2'\` |
| \`scripts/characters.js\` | \`enabled && version === '2'\` |
| \`scripts/scroll-to-watched.js\` | \`enabled && version === '2'\` |
| \`scripts/remove-image-sizes.js\` | \`enabled && version === '2'\` |

\`auto-select\` est traité différemment car la sélection auto du lecteur et l'auto-clic sur \"Valider\" sont des features utiles indépendamment de la version du thème, et la logique est compatible avec la v1 legacy.

## Test plan

- [x] v2 + enabled → toutes les features actives ✅
- [x] v2 + désactivé → aucune feature visible (pas de \"Voir la VF\", pas de section personnages, pas de boutons flottants)
- [x] v1 + enabled → seul auto-select fonctionne (pour ceux qui ont activé l'option dans le popup), le reste est inactif
- [x] v1 + désactivé → rien ne fonctionne, comme attendu